### PR TITLE
DON’T create a lambda when a tear-off will do

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,9 +33,7 @@ class _HomePageState extends State<HomePage> {
             _image = geteditimage;
           });
         }
-      }).catchError((er) {
-        print(er);
-      });
+      }).catchError(print);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
For good practice and avoid code warning, you can refer to [#Dart documentation](https://dart.dev/guides/language/effective-dart/usage#dont-create-a-lambda-when-a-tear-off-will-do).